### PR TITLE
Add check for string type for getVariableDescriptors function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oci-metrics-datasource",
   "private": true,
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Oracle Cloud Infrastructure Metrics Data Source for Grafana",
   "main": "index.js",
   "scripts": {

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -787,7 +787,7 @@ export default class OCIDatasource {
     const vars = this.templateSrv.variables || [];
 
     if (regex) {
-      let regexVars = vars.filter((item) => item.query.match(regex) !== null);
+      let regexVars = vars.filter((item) => _.isString(item.query) && item.query.match(regex) !== null);
       if (includeCustom) {
         const custom = vars.filter(
           (item) => item.type === "custom" || item.type === "constant"

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -29,8 +29,8 @@
       },
       { "name": "UPL", "url": "https://oss.oracle.com/licenses/upl" }
     ],
-    "version": "3.0.2",
-    "updated": "2022-02-09"
+    "version": "3.0.3",
+    "updated": "2022-02-10"
   },
 
   "dependencies": {


### PR DESCRIPTION
Fixes variable issue when incorporating data source with different query type. 

To recreate:
Include another data source such as Prometheus: https://prometheus.io/docs/prometheus/latest/getting_started/
Create a template variable based on Prometheus data source, use any valid query such as:
![image](https://user-images.githubusercontent.com/17230520/153523933-0407afae-b7a9-43f3-98ed-4540876c1db3.png)

Proof:
![grafana_variable_fix](https://user-images.githubusercontent.com/17230520/153523805-1506bb04-e0db-4c38-a874-af0e45664e68.gif)

