### PR TITLE
Return a new query from applyTemplateVariables instead of modifying the query in place.

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -90,9 +90,18 @@ export class OCIDataSource extends DataSourceWithBackend<OCIQuery, OCIDataSource
     interpolatedQ.queryTextRaw = templateSrv.replace(interpolatedQ.queryTextRaw, scopedVars);
 
     if (interpolatedQ.dimensionValues) {
-      interpolatedQ.dimensionValues = interpolatedQ.dimensionValues.map(value => 
-        templateSrv.replace(value, scopedVars)
-      );
+      for (let i = 0; i < interpolatedQ.dimensionValues.length; i++) {
+        interpolatedQ.dimensionValues[i] = templateSrv.replace(interpolatedQ.dimensionValues[i], scopedVars);
+      }
+    }
+    if (interpolatedQ.tenancy) {
+      interpolatedQ.tenancy = templateSrv.replace(interpolatedQ.tenancy, scopedVars);
+    }
+    if (interpolatedQ.compartment) {
+      interpolatedQ.compartment = templateSrv.replace(interpolatedQ.compartment, scopedVars, this.compartmentFormatter);
+    }
+    if (interpolatedQ.resourcegroup) {
+      interpolatedQ.resourcegroup = templateSrv.replace(interpolatedQ.resourcegroup, scopedVars);
     }
     
     const queryModel = new QueryModel(interpolatedQ, getTemplateSrv());
@@ -103,6 +112,7 @@ export class OCIDataSource extends DataSourceWithBackend<OCIQuery, OCIDataSource
       } else {
         interpolatedQ.queryText = queryModel.buildQuery(String(interpolatedQ.metric));
       }
+      
     }    
     return interpolatedQ;
   }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -37,7 +37,6 @@ export class OCIDataSource extends DataSourceWithBackend<OCIQuery, OCIDataSource
   constructor(instanceSettings: DataSourceInstanceSettings<OCIDataSourceOptions>) {
     super(instanceSettings);
     this.jsonData = instanceSettings.jsonData;
-    
   }
  
 


### PR DESCRIPTION
From Grafana 11.3 when the scenes framework replaced the old architecture for dashboards queries are handled a bit differently when passed to query editors. This surfaced a bug with the query editor for oci-grafana-metrics.

https://github.com/oracle/oci-grafana-metrics/issues/309

With the new architecture applyTemplateVariables is run when first entering into the edit mode of a panel. Because applyTemplateVariables in this datasource plugin is modifying the query in place, the query received by the query editor has had its template variables substituted. The query editor needs to work with a raw query.

This change creates a deep copy of the query and modifies the copy before returning it.