### PR TITLE
Fix multi-series datapoint corruption for sparse series (misaligned timestamp realignment)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oci-metrics-datasource",
   "private": true,
-  "version": "6.5.6",
+  "version": "6.5.7-tbean.1",
   "description": "Oracle Cloud Infrastructure Metrics Data Source for Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/plugin/metrics_functions.go
+++ b/pkg/plugin/metrics_functions.go
@@ -586,7 +586,8 @@ func (o *OCIDatasource) GetNamespaceWithMetricNames(
 //
 // Data Handling:
 //   - Handles fetching data for all regions in parallel when specified.
-//   - Adjusts data when different resource datapoints have a mismatched number of values.
+//   - Aligns series with mismatched timestamp sets to one shared time axis,
+//     leaving nulls (gaps) where a series has no datapoint of its own.
 //   - Supports filtering by resource group, dimensions, and tags.
 //   - Adds labels based on selected dimensions and tags.
 //   - Sorts the time slice for proper representation in Grafana.
@@ -599,7 +600,12 @@ func (o *OCIDatasource) GetMetricDataPoints(ctx context.Context, requestParams m
 	backend.Logger.Debug("fetching metric datapoints", "method", "GetMetricDataPoints", "compartment", requestParams.CompartmentOCID, "query", requestParams.QueryText)
 
 	times := []time.Time{}
-	dataValuesWithTime := map[common.SDKTime][]float64{}
+	// Each series keeps its own datapoints keyed by timestamp, and timestamps
+	// are collected into the union across all series. No value ever crosses
+	// series boundaries; a series simply has no entry at timestamps where OCI
+	// did not report a datapoint for it (see alignDataPointsToUnionTimestamps).
+	dataValuesPerSeries := map[int]map[common.SDKTime]float64{}
+	unionTimestamps := map[common.SDKTime]struct{}{}
 	dataPointsWithResourceSerialNo := map[int]models.OCIMetricDataPoints{}
 	dataPoints := []models.OCIMetricDataPoints{}
 	resourceIDsPerTag := map[string]map[string]struct{}{}
@@ -759,34 +765,17 @@ func (o *OCIDatasource) GetMetricDataPoints(ctx context.Context, requestParams m
 				return metricDatapoints[i].Timestamp.Time.Before(metricDatapoints[j].Timestamp.Time)
 			})
 
-			// sometimes 2 different resource datapoint have mismatched no of values
-			// to make it equal fill the extra point with previous value
+			// Series may report datapoints at different timestamps (e.g. OCI
+			// object storage emits datapoints only for buckets with traffic).
+			// Keep each series' datapoints keyed by its own timestamps only.
 			resourcesFetched += 1
-			previousValue := 0.0
+			seriesValues := map[common.SDKTime]float64{}
 			for _, eachMetricDataPoint := range metricDatapoints {
 				t := *eachMetricDataPoint.Timestamp
-				v := *eachMetricDataPoint.Value
-
-				if _, ok := dataValuesWithTime[t]; ok {
-					dataValuesWithTime[t] = append(dataValuesWithTime[t], v)
-					previousValue = v
-				} else {
-					if resourcesFetched == 1 {
-						dataValuesWithTime[t] = []float64{v}
-						previousValue = v
-						continue
-					}
-
-					// adjustment for previous non-existance values with the immediate previous value
-					// when the time comes in later data points
-					dataValuesWithTime[t] = []float64{previousValue}
-					for i := 2; i < resourcesFetched; i++ {
-						dataValuesWithTime[t] = append(dataValuesWithTime[t], previousValue)
-					}
-					dataValuesWithTime[t] = append(dataValuesWithTime[t], v)
-					previousValue = v
-				}
+				seriesValues[t] = *eachMetricDataPoint.Value
+				unionTimestamps[t] = struct{}{}
 			}
+			dataValuesPerSeries[resourcesFetched-1] = seriesValues
 
 			// for base tenancy
 			splits := strings.Split(tenancyOCID, "/")
@@ -826,19 +815,9 @@ func (o *OCIDatasource) GetMetricDataPoints(ctx context.Context, requestParams m
 	})
 
 	timesToFetch := []common.SDKTime{}
-	// adjustment for later non-existance values with last value
-	for t, dvs := range dataValuesWithTime {
+	for t := range unionTimestamps {
 		times = append(times, t.Time)
 		timesToFetch = append(timesToFetch, t)
-
-		if len(dvs) == resourcesFetched {
-			continue
-		}
-
-		lastValue := dataValuesWithTime[t][len(dataValuesWithTime[t])-1]
-		for i := 0; i < resourcesFetched-len(dvs); i++ {
-			dataValuesWithTime[t] = append(dataValuesWithTime[t], lastValue)
-		}
 	}
 
 	// sorting the time slice, for grafana
@@ -850,15 +829,7 @@ func (o *OCIDatasource) GetMetricDataPoints(ctx context.Context, requestParams m
 		return timesToFetch[i].Time.Before(timesToFetch[j].Time)
 	})
 
-	dataValuesWithResourceSerialNo := map[int][]float64{}
-	// final preparation
-	for _, t := range timesToFetch {
-		dvIndex := 0
-		for i := 0; i < resourcesFetched; i++ {
-			dataValuesWithResourceSerialNo[i] = append(dataValuesWithResourceSerialNo[i], dataValuesWithTime[t][dvIndex])
-			dvIndex += 1
-		}
-	}
+	dataValuesWithResourceSerialNo := alignDataPointsToUnionTimestamps(resourcesFetched, dataValuesPerSeries, timesToFetch)
 
 	// extracting for grafana
 	for i, dps := range dataValuesWithResourceSerialNo {
@@ -869,6 +840,32 @@ func (o *OCIDatasource) GetMetricDataPoints(ctx context.Context, requestParams m
 	}
 
 	return times, dataPoints, nil
+}
+
+// alignDataPointsToUnionTimestamps builds one nullable value slice per series,
+// aligned to the sorted union of timestamps observed across all series.
+//
+// Correctness invariant: for every series i and timestamp t, output[i][t]
+// equals series i's own observed value at t, or nil if OCI did not report a
+// datapoint for that series at t. No value is ever carried forward or
+// borrowed from another series, and missing datapoints are never zero-filled;
+// Grafana renders the nulls as gaps, which is the only honest representation
+// of "OCI did not report". (Fixes oracle/oci-grafana-metrics#285 and #323:
+// the previous positional realignment padded sparse series with the values of
+// whichever series contributed last at a given timestamp.)
+func alignDataPointsToUnionTimestamps(resourcesFetched int, dataValuesPerSeries map[int]map[common.SDKTime]float64, timesToFetch []common.SDKTime) [][]*float64 {
+	dataValuesWithResourceSerialNo := make([][]*float64, resourcesFetched)
+	for i := 0; i < resourcesFetched; i++ {
+		seriesValues := dataValuesPerSeries[i]
+		aligned := make([]*float64, len(timesToFetch))
+		for j, t := range timesToFetch {
+			if v, ok := seriesValues[t]; ok {
+				aligned[j] = common.Float64(v)
+			}
+		}
+		dataValuesWithResourceSerialNo[i] = aligned
+	}
+	return dataValuesWithResourceSerialNo
 }
 
 // ****** WARNING This function is not implemented yet ******

--- a/pkg/plugin/metrics_functions_test.go
+++ b/pkg/plugin/metrics_functions_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/identity"
@@ -240,5 +241,125 @@ func TestListCompartmentsReturnsOtherErrors(t *testing.T) {
 				t.Fatalf("calls = %d, want 1", calls)
 			}
 		})
+	}
+}
+
+// sdkTimeAt returns a common.SDKTime n minutes after a fixed base time.
+func sdkTimeAt(base time.Time, minutes int) common.SDKTime {
+	return common.SDKTime{Time: base.Add(time.Duration(minutes) * time.Minute)}
+}
+
+// assertAlignedSeries checks that aligned[idx] contains exactly the expected
+// nullable values: the series' own value where present, nil where OCI did not
+// report a datapoint for it.
+func assertAlignedSeries(t *testing.T, aligned [][]*float64, idx int, label string, expected []*float64) {
+	t.Helper()
+	got := aligned[idx]
+	if len(got) != len(expected) {
+		t.Fatalf("series %s: length = %d, want %d", label, len(got), len(expected))
+	}
+	for j := range expected {
+		if expected[j] == nil {
+			if got[j] != nil {
+				t.Fatalf("series %s: datapoint %d = %v, want nil (no datapoint of its own at this timestamp)", label, j, *got[j])
+			}
+			continue
+		}
+		if got[j] == nil {
+			t.Fatalf("series %s: datapoint %d = nil, want %v", label, j, *expected[j])
+		}
+		if *got[j] != *expected[j] {
+			t.Fatalf("series %s: datapoint %d = %v, want %v", label, j, *got[j], *expected[j])
+		}
+	}
+}
+
+func float64Ptr(v float64) *float64 { return &v }
+
+// TestAlignDataPointsToUnionTimestamps reproduces the production data-corruption
+// failure from oracle/oci-grafana-metrics#285/#323: when series report
+// datapoints at different timestamps (e.g. OCI object storage only emits
+// datapoints for buckets with traffic), each series must keep its own values
+// and get nulls — never another series' values — at timestamps it did not
+// report.
+func TestAlignDataPointsToUnionTimestamps(t *testing.T) {
+	base := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+
+	// t1..t6
+	union := []common.SDKTime{
+		sdkTimeAt(base, 1), sdkTimeAt(base, 2), sdkTimeAt(base, 3),
+		sdkTimeAt(base, 4), sdkTimeAt(base, 5), sdkTimeAt(base, 6),
+	}
+
+	// Series A is dense (t1..t6), series B is sparse (only t2, t5),
+	// series C is sparse (only t3).
+	dataValuesPerSeries := map[int]map[common.SDKTime]float64{
+		0: {
+			union[0]: 1, union[1]: 2, union[2]: 3,
+			union[3]: 4, union[4]: 5, union[5]: 6,
+		},
+		1: {
+			union[1]: 20, union[4]: 50,
+		},
+		2: {
+			union[2]: 30,
+		},
+	}
+
+	aligned := alignDataPointsToUnionTimestamps(3, dataValuesPerSeries, union)
+
+	if len(aligned) != 3 {
+		t.Fatalf("aligned series count = %d, want 3", len(aligned))
+	}
+
+	// Series A keeps exactly its own six values.
+	assertAlignedSeries(t, aligned, 0, "A", []*float64{
+		float64Ptr(1), float64Ptr(2), float64Ptr(3),
+		float64Ptr(4), float64Ptr(5), float64Ptr(6),
+	})
+
+	// Series B has values only at t2 and t5, nil everywhere else. Under the
+	// old positional realignment B would have been padded with A's values;
+	// these nil assertions catch that regression.
+	assertAlignedSeries(t, aligned, 1, "B", []*float64{
+		nil, float64Ptr(20), nil, nil, float64Ptr(50), nil,
+	})
+
+	// Series C has a value only at t3.
+	assertAlignedSeries(t, aligned, 2, "C", []*float64{
+		nil, nil, float64Ptr(30), nil, nil, nil,
+	})
+
+	// No value ever crosses series: every populated cell equals the value the
+	// series itself reported, not a neighbor's (e.g. B at t2 must be 20, not
+	// A's 2).
+	for i, want := range dataValuesPerSeries {
+		for ts, v := range want {
+			var j int
+			for j = range union {
+				if union[j] == ts {
+					break
+				}
+			}
+			if got := aligned[i][j]; got == nil || *got != v {
+				t.Fatalf("series %d at %v = %v, want its own value %v", i, ts.Time, got, v)
+			}
+		}
+	}
+}
+
+func TestAlignDataPointsToUnionTimestampsEdgeCases(t *testing.T) {
+	base := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	union := []common.SDKTime{sdkTimeAt(base, 1), sdkTimeAt(base, 2)}
+
+	// Single series with all timestamps present is unchanged.
+	single := alignDataPointsToUnionTimestamps(1, map[int]map[common.SDKTime]float64{
+		0: {union[0]: 7, union[1]: 8},
+	}, union)
+	assertAlignedSeries(t, single, 0, "single", []*float64{float64Ptr(7), float64Ptr(8)})
+
+	// Zero resources yields no series.
+	if got := alignDataPointsToUnionTimestamps(0, map[int]map[common.SDKTime]float64{}, union); len(got) != 0 {
+		t.Fatalf("zero-resources alignment returned %d series, want 0", len(got))
 	}
 }

--- a/pkg/plugin/models/oci.go
+++ b/pkg/plugin/models/oci.go
@@ -61,8 +61,10 @@ type OCIMetricDataPoints struct {
 	UniqueDataID string
 	// DimensionKey is the key of the dimension used to identify the resource.
 	DimensionKey string
-	// DataPoints is a list of float64 values representing the metric data points.
-	DataPoints []float64
+	// DataPoints is a list of nullable float64 values representing the metric data points.
+	// A nil entry means OCI did not report a datapoint for this series at the
+	// corresponding timestamp; it is never filled with another series' value.
+	DataPoints []*float64
 	// Labels is a map of string to string representing the labels for the metric data.
 	Labels map[string]string
 }

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -21,22 +21,27 @@
         "name": "GitHub",
         "url": "https://github.com/oracle/oci-grafana-metrics"
       },
-      { "name": "UPL", "url": "https://oss.oracle.com/licenses/upl" }
-    ],
-    "version": "6.5.6",
-    "updated": "2026-07-08",
-    "screenshots":[
       {
-        "name":"OCI Metrics Dashboard",
-        "path":"img/OCI_Metrics.png"
+        "name": "UPL",
+        "url": "https://oss.oracle.com/licenses/upl"
+      }
+    ],
+    "version": "6.5.7-tbean.1",
+    "updated": "2026-07-08",
+    "screenshots": [
+      {
+        "name": "OCI Metrics Dashboard",
+        "path": "img/OCI_Metrics.png"
       }
     ],
     "keywords": [
-      "oci", "oracle", "metrics"
+      "oci",
+      "oracle",
+      "metrics"
     ]
   },
   "dependencies": {
     "grafanaDependency": ">=9.0.0",
-    "plugins": [ ]
+    "plugins": []
   }
 }


### PR DESCRIPTION
## Problem

`GetMetricDataPoints` realigns multi-series `SummarizeMetricsData` responses **positionally** instead of per-series:

- `dataValuesWithTime map[common.SDKTime][]float64` appends each series' values to a timestamp's slice as they are encountered, mixing series that share or don't share timestamps.
- A later loop pads slices shorter than the series count with the **last contributing value** of that slice — i.e. a sparse series (e.g. an OCI bucket that only emits datapoints when it has traffic) gets padded with a *neighboring series'* values and plots a byte-identical copy of another resource's curve.
- The final per-series extraction indexes those mixed slices positionally, so the fabricated values land in the Grafana frame.

Reproduced in production with `oci_objectstorage` per-bucket metrics: sparse buckets returned exact duplicates of the densest bucket's series, while `SummarizeMetricsData` via the OCI API shows the buckets are completely different. Same symptom as #285 and #323.

## Fix

- Each series now keeps its own datapoints in a per-series `map[common.SDKTime]float64`; no positional appends across series.
- A new pure helper `alignDataPointsToUnionTimestamps` emits each series aligned to the sorted union of all timestamps, with **null where OCI reported no datapoint** — no carry-forward and no cross-series borrowing. `OCIMetricDataPoints.DataPoints` is now `[]*float64`; the grafana-plugin-sdk-go maps this to a nullable float vector, so frames render gaps instead of fabricated continuations.
- Response ordering/serial numbering, label assembly, multi-region merge, and timestamp sorting are unchanged.

## Tests

- New `TestAlignDataPointsToUnionTimestamps`: dense series A (t1..t6), sparse series B (t2, t5) and C (t3); asserts each series keeps exactly its own values and nils elsewhere — this fails against the old padding behavior. Plus edge cases for a single dense series and zero series.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass. No existing test covered `GetMetricDataPoints`, so none had to be migrated.

## Behavior note

Dashboards that unknowingly relied on the fabricated carry-forward will now show honest gaps where OCI reports nothing for a series in the window. Sparse busy/idle resource mixes (e.g. per-bucket object storage panels) finally show correct per-resource curves.